### PR TITLE
Tiny typo... but not sure it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ python run.py
 Now that the server is running, go to (http://localhost:5000) to use IGV.
 To view one of the example tracks, click on it in the box in the upper left corner.
 
-Alternatively, you can set the environment variable FLASK_APP to ijvjs.py and use 'flask run':
+Alternatively, you can set the environment variable FLASK_APP to igvjs.py and use 'flask run':
 ```sh
 export FLASK_APP=igvjs.py
 flask run


### PR DESCRIPTION
The main instructions work but I when I tried the prescribed alternative (within a PyCharms bash terminal session with a dedicated virtualenv):

```sh
export FLASK_APP=igvjs.py
flask run
```
I couldn't get it to work. I am wondering whether the instructions are incomplete. It's been awhile since I've used flask.. perhaps I'm missing something obvious here. Sorry for my ignorance!